### PR TITLE
Add [nonfunctional] choose-senders page

### DIFF
--- a/letters/apps/matchmaker/admin.py
+++ b/letters/apps/matchmaker/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from .models import Sender, Receiver
 
+
 @admin.register(Sender)
 class SenderAdmin(admin.ModelAdmin):
     list_display = (
@@ -22,8 +23,17 @@ class SenderAdmin(admin.ModelAdmin):
 
     edit_url.allow_tags = True
 
+
 @admin.register(Receiver)
-class SenderAdmin(admin.ModelAdmin):
+class ReceiverAdmin(admin.ModelAdmin):
     list_display = (
         'uuid',
+        'choose_senders',
     )
+
+    def choose_senders(self, instance):
+        return '<a href="{}">[Link to choose senders]</a>'.format(
+            instance.make_authenticated_choose_senders_url()
+        )
+
+    choose_senders.allow_tags = True

--- a/letters/apps/matchmaker/models.py
+++ b/letters/apps/matchmaker/models.py
@@ -55,6 +55,7 @@ class Sender(models.Model):
             kwargs={'json_web_token': self.make_json_web_token()}
         )
 
+
 class Receiver(models.Model):
 
     uuid = models.UUIDField(
@@ -70,3 +71,9 @@ class Receiver(models.Model):
 
         result = jwt.encode(data, settings.SECRET_KEY)
         return result
+
+    def make_authenticated_choose_senders_url(self):
+        return reverse(
+            'receiver-choose-senders',
+            kwargs={'json_web_token': self.make_json_web_token()}
+        )

--- a/letters/apps/matchmaker/templates/matchmaker/pick_writers.html
+++ b/letters/apps/matchmaker/templates/matchmaker/pick_writers.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block body_inner %}
-
-
-
-{% endblock %}

--- a/letters/apps/matchmaker/templates/matchmaker/receiver_choose_senders.html
+++ b/letters/apps/matchmaker/templates/matchmaker/receiver_choose_senders.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block body_inner %}
+
+<section>
+  <h1>Who would you like to get a letter from?</h1>
+
+  <ul>
+  {% for sender in senders %}
+    <li>{{ sender.first_name }}</li>
+  {% endfor %}
+  </ul>
+
+
+
+</section>
+
+{% endblock %}

--- a/letters/apps/matchmaker/urls.py
+++ b/letters/apps/matchmaker/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 
-from .views import UpdateSenderProfileView, SenderProfileDetailView
+from .views import (
+    UpdateSenderProfileView, SenderProfileDetailView, ReceiverChooseSendersView
+)
 
 JWT_PATTERN = "[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*"
 
@@ -15,6 +17,12 @@ urlpatterns = [
         r'^sender/profile/(?P<json_web_token>' + JWT_PATTERN + ')/$',
         SenderProfileDetailView.as_view(),
         name='sender-profile-detail'
+    ),
+
+    url(
+        r'^receiver/choose-senders/(?P<json_web_token>' + JWT_PATTERN + ')/$',
+        ReceiverChooseSendersView.as_view(),
+        name='receiver-choose-senders'
     ),
 
 ]


### PR DESCRIPTION
Thanks @jamesarice for your previous WIP branch.

Now from the admin you can follow a link for the receiver:

![image](https://user-images.githubusercontent.com/254290/31015585-cf873400-a518-11e7-81b0-741da43fa127.png)

Which currently just lists all possible senders:

![image](https://user-images.githubusercontent.com/254290/31015623-fc2ac6e8-a518-11e7-8a11-7cf435e83441.png)
