### PR TITLE
Revert: sender->writer rename for existing json web tokens

### DIFF
--- a/letters/apps/matchmaker/models.py
+++ b/letters/apps/matchmaker/models.py
@@ -51,6 +51,7 @@ class Writer(models.Model):
         data = {
             'exp': datetime.datetime.utcnow() + datetime.timedelta(days=30),
             'writer_uuid': str(self.uuid),
+            'sender_uuid': str(self.uuid),
         }
 
         result = jwt.encode(data, settings.SECRET_KEY)

--- a/letters/apps/matchmaker/views.py
+++ b/letters/apps/matchmaker/views.py
@@ -33,7 +33,7 @@ class GetObjectFromJWT:
 
 class GetWriterObjectFromJWTMixin(GetObjectFromJWT):
     object_class = Writer
-    uuid_key = 'writer_uuid'
+    uuid_key = 'sender_uuid'  # TODO: rename to writer_uuid
 
 
 class GetReaderObjectFromJWTMixin(GetObjectFromJWT):


### PR DESCRIPTION
- when creating a JWT, add both `writer_uuid` AND `sender_uuid`
- when *reading* a JWT, use `sender_uuid`

This way, in time we will be able to switch to using `writer_uuid`