### PR TITLE
Run PEP8 style tests for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
 env:
   matrix:
     - DJANGO_SETTINGS_MODULE=letters.settings.production DATABASE_URL=postgres://postgres:@localhost:5432/mydatabase SECRET_KEY=abcdefghijklmnopqrstuvwxyz
+install:
+    - pip install -r requirements.txt
+    - pip install -r requirements_for_testing.txt
 before_script:
   - psql -c 'create database mydatabase;' -U postgres
 script:

--- a/letters/apps/matchmaker/models.py
+++ b/letters/apps/matchmaker/models.py
@@ -17,7 +17,10 @@ class Writer(models.Model):
 
     first_name = models.CharField(
         max_length=128,
-        help_text="We only ask for your first name so that your identity is protected."
+        help_text=(
+            "We only ask for your first name so that your identity is "
+            "protected."
+        )
     )
 
     private_story = models.TextField(
@@ -31,13 +34,19 @@ class Writer(models.Model):
 
     profile_story = models.TextField(
         blank=True,
-        help_text="A short summary will help people who need support find a letter writer they can relate to."
+        help_text=(
+            "A short summary will help people who need support find a letter "
+            "writer they can relate to."
+        )
     )
 
     age = models.IntegerField(
         blank=True,
         null=True,
-        help_text="This will help people who want to receive a letter make a decision about who writes to them."
+        help_text=(
+            "This will help people who want to receive a letter make a "
+            "decision about who writes to them."
+        )
     )
 
     training_complete = models.BooleanField(

--- a/letters/settings/common.py
+++ b/letters/settings/common.py
@@ -74,22 +74,30 @@ TEMPLATES = [
 WSGI_APPLICATION = 'letters.wsgi.application'
 
 
-
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': (
+            'django.contrib.auth.password_validation.'
+            'UserAttributeSimilarityValidator'
+        ),
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'NAME': (
+            'django.contrib.auth.password_validation.MinimumLengthValidator'
+        ),
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        'NAME': (
+            'django.contrib.auth.password_validation.CommonPasswordValidator'
+        ),
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        'NAME': (
+            'django.contrib.auth.password_validation.NumericPasswordValidator'
+        ),
     },
 ]
 

--- a/requirements_for_testing.txt
+++ b/requirements_for_testing.txt
@@ -1,0 +1,2 @@
+flake8==3.4.1
+pyflakes==1.5.0

--- a/test.sh
+++ b/test.sh
@@ -34,7 +34,7 @@ run_more_pep8_checks() {
     # F401: don't allow `imported but unused` except in __init__.py, settings
     flake8 \
         --select=F401 \
-        --exclude='*/__init__.py,letters/settings/*.py' \
+        --exclude='*/__init__.py,letters/settings/*.py,manage.py' \
     .
 }
 

--- a/test.sh
+++ b/test.sh
@@ -54,7 +54,7 @@ test_that_no_models_need_migrations() {
 }
 
 nuke_pyc_files
-# run_pep8_style_checks
+run_pep8_style_checks
 run_python_unit_tests
-# run_more_pep8_checks
+run_more_pep8_checks
 test_that_no_models_need_migrations


### PR DESCRIPTION
It's helpful to eliminate PEP8 warnings since they obscure genuine errors (like
references to unset variables) in editor linters.