### PR TITLE
Add date_expecting_letter to allocation emails

### DIFF
--- a/letters/apps/matchmaker/templates/matchmaker/allocation_emails/writer_midway.html
+++ b/letters/apps/matchmaker/templates/matchmaker/allocation_emails/writer_midway.html
@@ -20,7 +20,7 @@
 
   [IF READER PREFERENCE = DIRECT]TODO
 
-  <p>Don’t forget, {{ allocation.reader.first_name }} is expecting a letter from you by [date of last email + 14 days].</p>TODO
+  <p>Don’t forget, {{ allocation.reader.first_name }} is expecting a letter from you by {{ date_expecting_letter|date:"jS F" }}.</p>
 
   <p>If something’s changed and you don’t have time to write a letter to {{ allocation.reader.first_name }}, that’s fine, just let us know so we can ask someone else.</p>
 

--- a/letters/apps/matchmaker/templates/matchmaker/allocation_emails/writer_priming.html
+++ b/letters/apps/matchmaker/templates/matchmaker/allocation_emails/writer_priming.html
@@ -44,7 +44,7 @@
 
   {% endif %}
 
-  <p>{{ allocation.reader.first_name }} is expecting a letter from you by [TODO date + 14 days].</p>
+  <p>{{ allocation.reader.first_name }} is expecting a letter from you by {{ date_expecting_letter|date:"jS F" }}.</p>
 
   <p>Been ages since you wrote a letter? Read our <a href="{% url 'writer-guide' %}">Advice for letter writers</a>.</p>
 

--- a/letters/apps/matchmaker/views.py
+++ b/letters/apps/matchmaker/views.py
@@ -390,6 +390,26 @@ class AdminTaskListAllocationEmailView(DetailView):
             email_slug.replace('-', '_')
         )
 
+    def get_context_data(self, **kwargs):
+        existing_context = super(
+            AdminTaskListAllocationEmailView, self
+        ).get_context_data(**kwargs)
+
+        allocation = self.get_object()
+
+        existing_context.update(
+            {'date_expecting_letter': self._date_expecting_letter(allocation)}
+        )
+        return existing_context
+
+    def _date_expecting_letter(self, allocation):
+        delta = datetime.timedelta(days=14)
+
+        if allocation.writer_priming_email_sent:
+            return allocation.writer_priming_email_sent + delta
+        else:
+            return (timezone.now() + delta).date()
+
 
 class AdminAllocateWriters(ListView):
     model = WriterReaderSelection


### PR DESCRIPTION
A number of emails use this. The logic is:

1. if the priming_email_sent is set, it's 14 days after that date
2. if it's not set, it's 14 days after *today*

This change allows the allocation email templates to get this value from
the context.

*Update writer_priming and writer_midway with date_expecting_letter*